### PR TITLE
fix new brand and style guide link

### DIFF
--- a/misc/community-marketing-kit.md
+++ b/misc/community-marketing-kit.md
@@ -31,7 +31,7 @@ For every community, new or well established, it is always exciting to reach the
 
 ## Guidelines and downloadable [designlanguage.mozilla.org]
 
-With the new logo and the new look, we now have [a new brand guideline](designlanguage.mozilla.org) at a new home. If you have resources to create your own printable file, make sure to read the guideline on the DOs and DONTs and adhere to the guidelines and suggestions closely.
+With the new logo and the new look, we now have [a new brand guideline](https://designlanguage.mozilla.org) at a new home. If you have resources to create your own printable file, make sure to read the guideline on the DOs and DONTs and adhere to the guidelines and suggestions closely.
 
 ### Designs
 


### PR DESCRIPTION
https://designlanguage.mozilla.org

somehow *designlanguage.mozilla.org* when clicked is redirected within localizer-documentation umbrella.