### PR TITLE
Major change in mozorg dynamic section

### DIFF
--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -100,7 +100,7 @@ On the right side of the page:
 
 * Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
 * Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
-* Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction [below](#firefox/all-unified.lang]).)
+* Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page.
 * Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
 * The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
 
@@ -113,7 +113,7 @@ This page has been redesigned. The Tracking Protection feature is now part of Co
 * In step [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2), an extra text box appears which shows your current Content Blocking settings of the page.
 * Click on **Got it!** button to finish step three.
 * Click on **Restart tour** button to go through the above steps.
-* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to the topic on SUMO site. 
+* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to the topic on SUMO site.
 
 ### [navigation.lang](https://www.mozilla.org/)
 

--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -85,6 +85,7 @@ This section focuses on instructions for testing pages with dynamically generate
 Note: You may see different languages between mozilla.org, the login window, and the products above. If any of these products is not localized in your locale, it will fall back to English. Or it will fall back to your second language preference if the product is translated into that language.
 
 ### [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/)
+
 On the lower left side of the page:
 * These two sites are in English only: [Check the system requirements](https://www.mozilla.org/firefox/system-requirements/) and [Release notes](https://www.mozilla.org/firefox/notes/).
 * Click on the **Source code** link, you will be directed to the topic on [MDN](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code) site in your language if it is localized.

--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -35,7 +35,7 @@ It’s highly advised you to ask other community members to conduct peer review 
 * Nav bar terms consistent with the page titles they are linked to (except when Nav bar term is shortened due to space limitation).
 * Footer links don’t overlap with one another.
 
-You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.org/projects/mozillaorg/)
+You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.org/projects/mozillaorg/).
 
 ### Functionality testing
 
@@ -82,7 +82,7 @@ This section focuses on instructions for testing pages with dynamically generate
    * Firefox Monitor
    * Firefox Send
 
-Note: You may see different languages between mozilla.org, the login window, and the products above. If any of these products is not localized in your locale, it will fall back to English. Or it will fall back to your second language preference if the product is translated into that language.
+Note: You may see different languages between mozilla.org, the login window, and the products above. If any of these products is not localized in your locale, it will fall back to other languages set as preferred for content language negotiation, assuming any of them is available for the project, or English.
 
 ### [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/)
 
@@ -93,23 +93,23 @@ On the lower left side of the page:
 * Click on the **Need Help** link, you will be directed to the [SUMO](https://support.mozilla.org/products?utm_source=mozilla.org&utm_medium=referral&utm_campaign=need-help-link) home page.
 
 On the right side of the page:
-* Click on the ````?```` at the end of **Which browser would you like to download?**, a popup window shows the descriptions of different versions of Firefox available for download.
-* Click on the ````?```` at the end of **Select your preferred installer**, a popup window shows the descriptions of different versions of installers available for download.
+* Click on the `?` at the end of **Which browser would you like to download?**, a popup window shows the descriptions of different versions of Firefox available for download.
+* Click on the `?` at the end of **Select your preferred installer**, a popup window shows the descriptions of different versions of installers available for download.
 * Under the section of **Select your preferred language**, check whether your current preferred language is shown by default. Change to a different language, check whether the download summary above the **Download Now** button corresponds to your new selection.
 
 ### [firefox/new/trailhead.lang](https://www.mozilla.org/firefox/new/)
 
-* Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
+* Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download.
 * Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
 * Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page.
-* Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
+* Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings) article in your language if it is localized.
 * The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
 
 ### firefox/tracking-protection-tour.lang
 
 This page has been redesigned. The Tracking Protection feature is now part of Content Blocking, a collection of Firefox privacy features. It now points users to the SUMO page to better understand the topics. In order to check the localized content of this tour, you need to do the following:
 * Open the browser by selecting either New Window or New Private Window.
-* Copy and paste [step one](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=1&variation=0) URL to your browse, then hit the "return" or "enter" keyboard button. A text box pops up.
+* Copy and paste [step one](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=1&variation=0) URL to your browse, then hit the “return” or “enter” keyboard button. A text box pops up.
 * Click the **Next** button, which takes you to steps [two](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=2&variation=1) and [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2).
 * In step [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2), an extra text box appears which shows your current Content Blocking settings of the page.
 * Click on **Got it!** button to finish step three.
@@ -119,6 +119,6 @@ This page has been redesigned. The Tracking Protection feature is now part of Co
 ### [navigation.lang](https://www.mozilla.org/)
 
 This page is activated on production whether it is localized or not. It is not an independent page but a file of shared content. When clicking on any of these topics on the navigation bar, **Firefox**, **Projects**, **Developers** or **About**, you will see a drop-down window with subcategory topics. Within each of the topics, there is a description and a few links to help you dive deeper further into a topic which takes you to a different page. When reviewing the content, keep in mind the following:
-* Not all links take you to a site that's localizable for all locales.
-* Not all products are offered in your locales.
+* Not all links take you to a site that’s localizable for all locales.
+* Not all products are offered in your locale.
 * Brand and product names must remain unchanged.

--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -63,7 +63,7 @@ In some cases, pages receive major updates that require a complete rewrite of th
 ### Sync and update frequencies
 
 * Pontoon syncs every 20 minutes to the repository.
-* The Dev server update every 15 minutes.
+* The Dev server updates every 15 minutes.
 
 If you work on Pontoon, it is safe to say that it will take less than an hour to see your changes reflected on the dev server.
 
@@ -77,7 +77,7 @@ This section focuses on instructions for testing pages with dynamically generate
 
 * Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
 * Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
-* Click on the **Download in another language** link, you will be directed to the [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction below.)
+* Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction [below](#firefox/all-unified.lang]).)
 * Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
 * The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
 
@@ -103,22 +103,22 @@ On the right side of the page:
    * Firefox Monitor
    * Firefox Send
 
-Note: You may see different languages between mozilla.org, the login window and the products above. If any of these products is not localized in your locale, it will fall back to the second language of your preference in the priority order you set in the browser. If the product is not localized in any of the languages selected in the preference, it will eventually default to English.
+Note: You may see different languages between mozilla.org, the login window and the products above. If any of these products is not localized in your locale, it will fall back to English. Or it will fall back to your second language preference if the product is translated into that language.
 
 ### firefox/tracking-protection-tour.lang
 
 This page has been redesigned. The Tracking Protection feature is now part of Content Blocking, a collection of Firefox privacy features. It now points users to the SUMO page to better understand the topics. In order to check the localized content of this tour, you need to do the following:
-* Open the browser by selecting either New Window or New Private Window
+* Open the browser by selecting either New Window or New Private Window.
 * Copy and paste [step one](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=1&variation=0) URL to your browse, then hit the "return" or "enter" keyboard button. A text box pops up.
 * Click the **Next** button, which takes you to steps [two](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=2&variation=1) and [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2).
 * In step [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2), an extra text box appears which shows your current Content Blocking settings of the page.
-* Click on **Got it!** button to finish step three
+* Click on **Got it!** button to finish step three.
 * Click on **Restart tour** button to go through the above steps.
-* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to SuMo site
+* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to SuMo site.
 
 ### [navigation.lang](https://www.mozilla.org/en-US/)
 
 This page is activated on production whether it is localized or not. It is not an independent page but a file of shared content. When clicking on any of these topics on the navigation bar, **Firefox**, **Projects**, **Developers** or **About**, you will see a drop-down window with subcategory topics. Within each of the topics, there is a description and a few links to help you dive deeper further into a topic which takes you to a different page. When reviewing the content, keep in mind the following:
-* Not all links take you to a site that's localizable for all locales
-* Not all products are offered in your locales
-* Brand and product names must remain unchanged
+* Not all links take you to a site that's localizable for all locales.
+* Not all products are offered in your locales.
+* Brand and product names must remain unchanged.

--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -73,16 +73,18 @@ When a project has a firm deadline to meet, it will be communicated through the 
 
 This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change over time to reflect product design updates. Linguistic testing is the main focus. The instructions below are detailed steps to get to the localized content so it can be reviewed in context.
 
-### [firefox/new/trailhead.lang](https://www.mozilla.org/firefox/new/)
+### [firefox/accounts-2019.lang](https://www.mozilla.org/firefox/accounts/)
 
-* Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
-* Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
-* Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction [below](#firefox/all-unified.lang]).)
-* Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
-* The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
+* Click the **Sign In to Monitor** button, you will be taken to the sign-in page in order to get to the [Firefox Monitor](https://monitor.firefox.com) site.
+* Click on the links under each of the following products:
+   * Firefox browser
+   * Firefox Lockwise
+   * Firefox Monitor
+   * Firefox Send
+
+Note: You may see different languages between mozilla.org, the login window, and the products above. If any of these products is not localized in your locale, it will fall back to English. Or it will fall back to your second language preference if the product is translated into that language.
 
 ### [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/)
-
 On the lower left side of the page:
 * These two sites are in English only: [Check the system requirements](https://www.mozilla.org/firefox/system-requirements/) and [Release notes](https://www.mozilla.org/firefox/notes/).
 * Click on the **Source code** link, you will be directed to the topic on [MDN](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code) site in your language if it is localized.
@@ -94,16 +96,13 @@ On the right side of the page:
 * Click on the ````?```` at the end of **Select your preferred installer**, a popup window shows the descriptions of different versions of installers available for download.
 * Under the section of **Select your preferred language**, check whether your current preferred language is shown by default. Change to a different language, check whether the download summary above the **Download Now** button corresponds to your new selection.
 
-### [firefox/accounts-2019.lang](https://www.mozilla.org/firefox/accounts/)
+### [firefox/new/trailhead.lang](https://www.mozilla.org/firefox/new/)
 
-* Click the **Sign In to Monitor** button, you will be taken to the sign-in page in order to get to the [Firefox Monitor](https://monitor.firefox.com) site.
-* Click on the links under each of the following products:
-   * Firefox browser
-   * Firefox Lockwise
-   * Firefox Monitor
-   * Firefox Send
-
-Note: You may see different languages between mozilla.org, the login window and the products above. If any of these products is not localized in your locale, it will fall back to English. Or it will fall back to your second language preference if the product is translated into that language.
+* Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
+* Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
+* Click on the **Download in another language** link, you will be directed to the [firefox/all](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction [below](#firefox/all-unified.lang]).)
+* Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
+* The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
 
 ### firefox/tracking-protection-tour.lang
 
@@ -114,9 +113,9 @@ This page has been redesigned. The Tracking Protection feature is now part of Co
 * In step [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2), an extra text box appears which shows your current Content Blocking settings of the page.
 * Click on **Got it!** button to finish step three.
 * Click on **Restart tour** button to go through the above steps.
-* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to SuMo site.
+* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to the topic on SUMO site. 
 
-### [navigation.lang](https://www.mozilla.org/en-US/)
+### [navigation.lang](https://www.mozilla.org/)
 
 This page is activated on production whether it is localized or not. It is not an independent page but a file of shared content. When clicking on any of these topics on the navigation bar, **Firefox**, **Projects**, **Developers** or **About**, you will see a drop-down window with subcategory topics. Within each of the topics, there is a description and a few links to help you dive deeper further into a topic which takes you to a different page. When reviewing the content, keep in mind the following:
 * Not all links take you to a site that's localizable for all locales.

--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -16,7 +16,7 @@ It’s highly advised you to ask other community members to conduct peer review 
 ### Pre-l10n test
 
 * Have your [glossary](https://transvision.mozfr.org/) available as a reference, select mozilla.org as Repository, your language as your Target Locale.
-* For terminology consistency, reference the product or site that the page is for, assuming the product or site is localized (e.g.: Firefox, Test Pilot).
+* For terminology consistency, reference the product or site that the page is for, assuming the product or site is localized (e.g.: Firefox, Monitor).
 * Have the matching US page up as reference, though some strings may not be identical due to A/B testing.
 * Have the project you just localized available for editing in Pontoon.
 
@@ -35,7 +35,7 @@ It’s highly advised you to ask other community members to conduct peer review 
 * Nav bar terms consistent with the page titles they are linked to (except when Nav bar term is shortened due to space limitation).
 * Footer links don’t overlap with one another.
 
-You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.org/projects/mozillaorg/) or [GitHub](https://github.com/mozilla-l10n/www.mozilla.org/).
+You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.org/projects/mozillaorg/)
 
 ### Functionality testing
 
@@ -58,65 +58,67 @@ Updated translations are pushed to the production server almost daily.
 
 When a brand new page is available for localization, it won’t be enabled in production until it’s fully localized. When existing pages receive updates with new strings, this new content won’t be displayed on production until localized, to avoid displaying a mix of English and localized text.
 
-In some cases pages receive major updates that require a complete rewrite of the template: if this happens, the old template is kept online only for a short period of time and, when removed, it will cause the URL to redirect users to the English version.
+In some cases, pages receive major updates that require a complete rewrite of the template. If this happens, the old template is kept online only for a short period of time and, when removed, it will cause the URL to redirect users to the English version.
 
 ### Sync and update frequencies
 
 * Pontoon syncs every 20 minutes to the repository.
-* Web Dashboard and the Dev server update every 15 minutes.
+* The Dev server update every 15 minutes.
 
-If you work on Pontoon, it is safe to say that it will take less than an hour to see your changes reflected on the dashboard and the dev server.
+If you work on Pontoon, it is safe to say that it will take less than an hour to see your changes reflected on the dev server.
 
-When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.
+When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects. You can also check out the deadline at page level in Pontoon.
 
 ## Testing dynamic pages
 
 This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change over time to reflect product design updates. Linguistic testing is the main focus. The instructions below are detailed steps to get to the localized content so it can be reviewed in context.
 
-### [firefox/desktop/tips.lang](https://www.mozilla.org/firefox/desktop/tips/)
+### [firefox/new/trailhead.lang](https://www.mozilla.org/firefox/new/)
 
-* Click on the **next** or **back** link to check out the tips on different features.
-* Highlighted text is the same as in English.
-* Text fits inside the box.
+* Click the **Download Now** button to check the [thank you](https://www.mozilla.org/en-US/firefox/download/thanks) page that triggers an automatic download if not logged in to a Firefox account. If you have already logged in, a window will be popped up to invite you to save the updated Firefox download.
+* Click on the **Advanced install options & other platforms** link, a pop-up window displays options in various platforms.
+* Click on the **Download in another language** link, you will be directed to the [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/) page. (See detailed testing instruction below.)
+* Click on the **Fix a problem** link, you will be directed to to this [SUMO](https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&utm_medium=referral&utm_campaign=fix-problem-link) article in your language if it is localized.
+* The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
 
-### [firefox/new/horizon.lang](https://www.mozilla.org/firefox/new/)
+### [firefox/all-unified.lang](https://www.mozilla.org/firefox/all/)
 
-* Once page is loaded, click on the link called **Download Firefox for another platform**.
-* For alternative message, change URL to [Scene2](https://www.mozilla.org/firefox/new/?scene=2).
-* To fully review the Firefox download page messages, tests must go through following scenarios:.
-  * Desktop: Windows, macOS, Linux.
-  * Mobile: Android and iOS.
-  * Updating from older version of Firefox to the latest vs. downloading for the first time.
+On the lower left side of the page:
+* These two sites are in English only: [Check the system requirements](https://www.mozilla.org/firefox/system-requirements/) and [Release notes](https://www.mozilla.org/firefox/notes/).
+* Click on the **Source code** link, you will be directed to the topic on [MDN](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code) site in your language if it is localized.
+* The [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/) document is localized in limited number of languages.
+* Click on the **Need Help** link, you will be directed to the [SUMO](https://support.mozilla.org/products?utm_source=mozilla.org&utm_medium=referral&utm_campaign=need-help-link) home page.
 
-### [firefox/sendto.lang](https://www-dev.allizom.org/styleguide/docs/send-to-device/)
+On the right side of the page:
+* Click on the ````?```` at the end of **Which browser would you like to download?**, a popup window shows the descriptions of different versions of Firefox available for download.
+* Click on the ````?```` at the end of **Select your preferred installer**, a popup window shows the descriptions of different versions of installers available for download.
+* Under the section of **Select your preferred language**, check whether your current preferred language is shown by default. Change to a different language, check whether the download summary above the **Download Now** button corresponds to your new selection.
 
-The test can be done for all locales only on staging. For production testing, only these locales are enabled: de, en-GB, en-ZA, es-AR, es-CL, es-ES, es-MX, fr, id, pl, pt-BR, and ru.
-* Enter a mobile phone number, a new page will be generated, suggesting the next action to take.
-* Enter a phone number in the wrong phone number format. This will prompt an error message.
+### [firefox/accounts-2019.lang](https://www.mozilla.org/firefox/accounts/)
+
+* Click the **Sign In to Monitor** button, you will be taken to the sign-in page in order to get to the [Firefox Monitor](https://monitor.firefox.com) site.
+* Click on the links under each of the following products:
+   * Firefox browser
+   * Firefox Lockwise
+   * Firefox Monitor
+   * Firefox Send
+
+Note: You may see different languages between mozilla.org, the login window and the products above. If any of these products is not localized in your locale, it will fall back to the second language of your preference in the priority order you set in the browser. If the product is not localized in any of the languages selected in the preference, it will eventually default to English.
 
 ### firefox/tracking-protection-tour.lang
 
-* Open Firefox and start a New Private Window.
-* Once the window is launched, click on **See how it works** button.
-* You are taken to [step one](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=1).
-* Click the **Next** button, it takes you to steps [two](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=3).
-* In step [three](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=3), an extra text box appears.
-* Click on **Disable protection for this session** button to generate a new “step three” message.
-* Click on **Enable protection** button to toggle between *enable* and *disable* protection messages.
-  * NOTE: in order to see the message of **Disable protection for this site**, the browser must be in _normal mode_.
-* Click on **Got it!** button to get to the next page.
+This page has been redesigned. The Tracking Protection feature is now part of Content Blocking, a collection of Firefox privacy features. It now points users to the SUMO page to better understand the topics. In order to check the localized content of this tour, you need to do the following:
+* Open the browser by selecting either New Window or New Private Window
+* Copy and paste [step one](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=1&variation=0) URL to your browse, then hit the "return" or "enter" keyboard button. A text box pops up.
+* Click the **Next** button, which takes you to steps [two](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=2&variation=1) and [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2).
+* In step [three](https://www.mozilla.org/firefox/68.0.1/tracking-protection/start/?step=3&variation=2), an extra text box appears which shows your current Content Blocking settings of the page.
+* Click on **Got it!** button to finish step three
 * Click on **Restart tour** button to go through the above steps.
+* Click on the [FAQ](https://support.mozilla.org/kb/what-happened-tracking-protection) link which takes you to SuMo site
 
-### [mozorg/about/history.lang](https://www.mozilla.org/about/history/)
+### [navigation.lang](https://www.mozilla.org/en-US/)
 
-* The slides should automatically scroll to the next in about 10 seconds or so.
-* If it does not or it stops, click the next or previous arrows to go to the next slide.
-* Be sure to cycle through until you see the first slide again to ensure you have covered all the slides.
-* Text fits inside the box.
-
-### [mozorg/about/manifesto.lang](https://www.mozilla.org/about/manifesto/)
-
-You can check out the principles of the manifesto without going to the slide mode. However, only in the slide mode, all the localized content can be reviewed.
-* Click on the first principle.
-* Click on the “next” and the “previous” arrows to move from one slide to the next.
-* Check on text layout, alignment and wrapping. Box size should be adjustable to fit all the content.
+This page is activated on production whether it is localized or not. It is not an independent page but a file of shared content. When clicking on any of these topics on the navigation bar, **Firefox**, **Projects**, **Developers** or **About**, you will see a drop-down window with subcategory topics. Within each of the topics, there is a description and a few links to help you dive deeper further into a topic which takes you to a different page. When reviewing the content, keep in mind the following:
+* Not all links take you to a site that's localizable for all locales
+* Not all products are offered in your locales
+* Brand and product names must remain unchanged


### PR DESCRIPTION
**REMOVED**:
1) Obsolete:
* firefox/desktop/tips.lang
* firefox/new/horizon.lang

2) Format change, no longer dynamic: 
* mozorg/about/history.lang
* mozorg/about/manifesto.lang

3) Couldn't find updated info
* firefox/sendto.lang

**NEW**
* firefox/new/trailhead.lang
* firefox/all-unified.lang
* firefox/accounts-2019.lang
* navigation.lang

**REVISED**
* firefox/tracking-protection-tour.lang (tour isn't triggered automatically)



