### PR TITLE
Note on downloading TBX v2 files

### DIFF
--- a/src/tools/pontoon/translate.md
+++ b/src/tools/pontoon/translate.md
@@ -132,12 +132,20 @@ When you upload translations to Pontoon:
 * Existing strings with matching translations will be ignored.
 * New strings and new translations will be imported and attributed to the user uploading the file.
 
-## Downloading .tmx files via command line
+## Downloading .tbx and .tmx files via command line
 
-Translation memory (.tmx) files can grow big in size over time. To download files via command line it is advised to use `curl` command with the `--compressed` flag to reduce download times and avoid request timeouts.
+Terminology (.tbx) and translation memory (.tmx) files can grow big in size over time. To download files via command line it is advised to use `curl` command with the `--compressed` flag to reduce download times and avoid request timeouts.
 
 Here's an example command to download German (de) .tmx file across all projects:
 
 ```
 curl -o de.all-projects.tmx --compressed https://pontoon.mozilla.org/de/all-projects/de.all-projects.tmx
+```
+
+Note that Terminology files can be downloaded in the TBX 2008 (v2) format in addition to the default TBX v3 format available via the profile menu.
+
+Here's an example command to download German (de) .tbx file in the TBX 2008 (v2) format:
+
+```
+curl -o de.v2.tbx --compressed https://pontoon.mozilla.org/terminology/de.v2.tbx
 ```


### PR DESCRIPTION
We've added the ability to download Terminology in the legacy format.

https://bugzilla.mozilla.org/show_bug.cgi?id=1658420