### PR TITLE
Update comms info

### DIFF
--- a/src/products/mozilla_org/testing.md
+++ b/src/products/mozilla_org/testing.md
@@ -119,14 +119,13 @@ If the mozilla.org project is not in your Pontoon dashboard, but the site is loc
 
 This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change over time to reflect product design updates. Linguistic testing is the main focus. The instructions below are detailed steps to get to the localized content so it can be reviewed in context.
 
-### [firefox/accounts-2019.ftl](https://www.mozilla.org/firefox/accounts/)
+### [firefox/accounts.ftl](https://www.mozilla.org/firefox/accounts/)
 
 * Click the **Sign In to Monitor** button, you will be taken to the sign-in page in order to get to the [Firefox Monitor](https://monitor.firefox.com) site.
 * Click on the links under each of the following products:
    * Firefox browser
    * Firefox Lockwise
    * Firefox Monitor
-   * Firefox Send
 
 Note: You may see different languages between mozilla.org, the login window, and the products above. If any of these products is not localized in your locale, it will fall back to other languages set as preferred for content language negotiation, assuming any of them is available for the project, or English.
 

--- a/src/webprojects/fxa.md
+++ b/src/webprojects/fxa.md
@@ -21,8 +21,8 @@ The above could change over time as the team is planning to migrate .po files to
 FxA lives in two file formats: .po and .ftl, both contain variable or placeable in the strings. The shorter the string, the more context you need to make sure you get the translation right. Look for clues or get clarifications through the following methods:
 
 * String comments: Pay attention to the comment or string ID. In Pontoon, the comments are displayed above the area where you can enter your translation for a string.
-* [Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org): ping the L10n PM in charge with any issues you may have.
-* [Web projects mailing list](https://groups.google.com/g/mozilla.dev.l10n.web): Raise questions here so others may benefit from the information.
+* [Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org): Ping the L10n PM in charge with any issues you may have.
+* [Localization on Discourse](https://discourse.mozilla.org/c/l10n/547): Follow announcement and discussions, and raise questions you have.
 
 ## Errors in translations can break the build for all languages
 
@@ -121,5 +121,5 @@ There are a few ways to report non-linguistic related bugs:
 
 * File an issue [here](https://github.com/mozilla/fxa-content-server-l10n/issues).
 * Ping in [the Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org) to the l10n PM responsible for the project.
-* Send an email to the [web projects mailing list](https://groups.google.com/g/mozilla.dev.l10n.web).
+* Comment on the string in Pontoon and ping the L10n PM responsible for the project.
 * Send a direct email to the l10n PM responsible for the project.

--- a/src/webprojects/fxa.md
+++ b/src/webprojects/fxa.md
@@ -121,5 +121,5 @@ There are a few ways to report non-linguistic related bugs:
 
 * File an issue [here](https://github.com/mozilla/fxa-content-server-l10n/issues).
 * Ping in [the Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org) to the l10n PM responsible for the project.
-* Comment on the string in Pontoon and ping the L10n PM responsible for the project.
-* Send a direct email to the l10n PM responsible for the project.
+* Through Pontoon, click the REQUEST CONTEXT or REPORT ISSUE button next to the string and make a comment. This will notify the l10n PM in charge.
+* Send a direct email to the l10n PM responsible for the project. The email address can be found in the profile in Pontoon.

--- a/src/webprojects/sumo.md
+++ b/src/webprojects/sumo.md
@@ -45,7 +45,7 @@ Localization updates are pushed to the staging and production environments usual
 
 ## FAQ
 
-For any additional questions not covered here, you can contact [Rubén](mailto:nukeador@mozilla.com).
+For any additional questions not covered here, you can reach out to the #sumo room in [Matrix](https://chat.mozilla.org/#/room/#sumo:mozilla.org0) to discuss it.
 
 ### How often are new strings added? Is there a sprint?
 
@@ -61,8 +61,11 @@ Only when there is a release or a major change will there be communications to l
 
 ### What are the ways to report an issue?
 
-The best place to report issues is by filing [bugs to SUMO](https://bugzilla.mozilla.org/enter_bug.cgi?product=support.mozilla.org&component=Localization). This is the quickest way to have a problem resolved.
-
-Alternatively, you can report a problem through the SUMO l10n forum. You can also raise questions through [web projects mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web), in the #sumo channel on [Discourse](https://discourse.mozilla.org/c/sumo/), and other social channels. In the end, issues identified will be tracked through Bugzilla.
+* File a [bug to SUMO](https://bugzilla.mozilla.org/enter_bug.cgi?product=support.mozilla.org&component=Localization). This is the quickest way to have a problem resolved.
+* Discuss it in [the SUMO l10n forum](https://support.mozilla.org/forums/l10n-forum)
+* Raise questions in the #sumo channel on [Discourse](https://discourse.mozilla.org/c/sumo/)
+* Ping in [the Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org) to the l10n PM responsible for the project.
+* Comment on the string in Pontoon and ping the L10n PM responsible for the project.
+* Send a direct email to the l10n PM responsible for the project.
 
 It is not recommended to file issues on [GitHub sumo-l10n](https://github.com/mozilla-l10n/sumo-l10n/issues?q=is%3Aopen+is%3Aissue).

--- a/src/webprojects/sumo.md
+++ b/src/webprojects/sumo.md
@@ -61,11 +61,11 @@ Only when there is a release or a major change will there be communications to l
 
 ### What are the ways to report an issue?
 
-* File a [bug to SUMO](https://bugzilla.mozilla.org/enter_bug.cgi?product=support.mozilla.org&component=Localization). This is the quickest way to have a problem resolved.
-* Discuss it in [the SUMO l10n forum](https://support.mozilla.org/forums/l10n-forum)
-* Raise questions in the #sumo channel on [Discourse](https://discourse.mozilla.org/c/sumo/)
-* Ping in [the Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org) to the l10n PM responsible for the project.
-* Comment on the string in Pontoon and ping the L10n PM responsible for the project.
-* Send a direct email to the l10n PM responsible for the project.
+* File a [bug for SUMO](https://bugzilla.mozilla.org/enter_bug.cgi?product=support.mozilla.org&component=Localization). This is the quickest way to have a problem resolved.
+* Discuss it in [the SUMO l10n forum](https://support.mozilla.org/forums/l10n-forum).
+* Raise questions in the SUMO category on [Discourse](https://discourse.mozilla.org/c/sumo/).
+* Ping in [the Matrix channel](https://chat.mozilla.org/#/room/#l10n-community:mozilla.org) the l10n PM responsible for the project.
+* Through Pontoon, click the REQUEST CONTEXT or REPORT ISSUE button next to the string and make a comment. This will notify the l10n PM in charge.
+* Send a direct email to the l10n PM responsible for the project. The email address can be found in the profile in Pontoon.
 
 It is not recommended to file issues on [GitHub sumo-l10n](https://github.com/mozilla-l10n/sumo-l10n/issues?q=is%3Aopen+is%3Aissue).

--- a/src/webprojects/sumo.md
+++ b/src/webprojects/sumo.md
@@ -45,7 +45,7 @@ Localization updates are pushed to the staging and production environments usual
 
 ## FAQ
 
-For any additional questions not covered here, you can reach out to the #sumo room in [Matrix](https://chat.mozilla.org/#/room/#sumo:mozilla.org0) to discuss it.
+For any additional questions not covered here, you can reach out to the #sumo room in [Matrix](https://chat.mozilla.org/#/room/#sumo:mozilla.org) to discuss it.
 
 ### How often are new strings added? Is there a sprint?
 


### PR DESCRIPTION
- remove reference to dev-l10n-web as communication channel
- add matrix and discourse as alternatives
- remove obsolete information.