### PR TITLE
Updated localizer documentation for mobile

### DIFF
--- a/src/products/firefox_android/how_to_localize.md
+++ b/src/products/firefox_android/how_to_localize.md
@@ -2,7 +2,7 @@
 
 Firefox for Android is on a four week rapid release cycle. This means that usually there is a new release going out every four weeks.
 
-Within this timeframe, localizers will usually have four weeks to localize and test their strings for a given release: strings land continuously during the first two weeks, and then stop landing for two weeks so that localizers can complete their work. The deadline in [Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/) is an indicator of when the next localization cut-off date is for the upcoming release - in other words, the last day to get localization updates into that release.
+Within this timeframe, localizers will usually have approximately four weeks to localize and test their strings for a given release: strings land continuously on [Nightly](https://play.google.com/store/apps/details?id=org.mozilla.fenix) during the first four weeks, and then these strings ride the train to the [Beta version](https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta). The deadline in [Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/) is an indicator of when the next localization cut-off date is for the upcoming release - in other words, the last day to get localization updates into that release.
 
 Note that all files contained in the project should be localized in order for Firefox for Android to be complete.
 

--- a/src/products/firefox_android/how_to_localize.md
+++ b/src/products/firefox_android/how_to_localize.md
@@ -2,16 +2,16 @@
 
 Firefox for Android is on a four week rapid release cycle. This means that usually there is a new release going out every four weeks.
 
-Within this timeframe, localizers will usually have four weeks to localize and test their strings for a given release: strings land continuously during the first two weeks, and then stop landing for two weeks so that localizers can complete their work. The deadline in Pontoon is an indicator of when the next localization cut-off date is for the upcoming release - in other words, the last day to get localization updates into that release.
+Within this timeframe, localizers will usually have four weeks to localize and test their strings for a given release: strings land continuously during the first two weeks, and then stop landing for two weeks so that localizers can complete their work. The deadline in [Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/) is an indicator of when the next localization cut-off date is for the upcoming release - in other words, the last day to get localization updates into that release.
+
+Note that all files contained in the project should be localized in order for Firefox for Android to be complete.
 
 ## Localize Firefox for Android in Pontoon
 
-If your locale has never been set up for any android-l10n project yet, you must fill out [this issue template](https://github.com/mozilla-l10n/android-l10n/issues/new?assignees=delphine&labels=&template=new-localization-request.md&title=Add+%5Blocale%5D+to+%5Bproduct%5D) in order to request to add your locale to “Fenix” (code name for Firefox for Android). You will be notified there once your locale is set up in Pontoon and the project is ready to be localized.
+Localizers should go to the [Firefox for Android page on Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/), and click "Request New Language". They will be notified by email once the locale is set up and the project is ready to be localized.
 
-Note: android-l10n is a meta project that covers several mobile products, all sharing common strings contained in elements called “Android Components”. Android Components (also internally called a-c) are a collection of Android libraries to build browsers or browser-like applications. The strings in Android Components serve various mobile products, such as Fenix. To simplify things, we’ve created [tags here in Pontoon](https://pontoon.mozilla.org/projects/android-l10n/tags/), so you can easily access all the product-specific strings needed, as well as the a-c ones (that are required as well for the products).
+When the locale has been set up, localizers can choose it from the list of locales on [Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/), and start localizing the product from there.
 
-When your locale has been set up, you can choose it from the list of locales on [Pontoon](https://pontoon.mozilla.org/projects/android-l10n/tags/fenix/), and start localizing the product from there.
+Once localization starts, the locale should become available in [Nightly builds](https://play.google.com/store/apps/details?id=org.mozilla.fenix) within the next few days, which will enable localizers to check and test their work ([see this section](testing.md) for more information about testing).
 
-Once you start localizing, your locale should become available in [Nightly builds](https://play.google.com/store/apps/details?id=org.mozilla.fenix) within the next few days, which will enable you to check and test your work ([see this section](testing.md) for more information about testing).
-
-When your locale reaches 70% completion (and given you have been testing actively), it can be added to release.
+When the locale reaches 70% completion (and given that active testing has taken place), it can be added to the [release version](https://play.google.com/store/apps/details?id=org.mozilla.firefox).

--- a/src/products/firefox_android/testing.md
+++ b/src/products/firefox_android/testing.md
@@ -26,4 +26,4 @@ Please note that it is strongly suggested to start using Nightly builds on a dai
 
 Also, it is important that builds are tested by people outside the localization team. Ask other people from your community to help test in order to have fresh eyes looking at your work.
 
-l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [the Discourse Localization channel](https://discourse.mozilla.org/c/l10n/). Please make sure you’re following this channel closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.
+l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [the Discourse Localization category](https://discourse.mozilla.org/c/l10n/). Please make sure you’re following this category closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.

--- a/src/products/firefox_android/testing.md
+++ b/src/products/firefox_android/testing.md
@@ -26,4 +26,4 @@ Please note that it is strongly suggested to start using Nightly builds on a dai
 
 Also, it is important that builds are tested by people outside the localization team. Ask other people from your community to help test in order to have fresh eyes looking at your work.
 
-l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n). Please make sure you’re following this list closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.
+l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [the Discourse Localization channel](https://discourse.mozilla.org/c/l10n/). Please make sure you’re following this channel closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.

--- a/src/products/firefox_android/testing.md
+++ b/src/products/firefox_android/testing.md
@@ -26,4 +26,4 @@ Please note that it is strongly suggested to start using Nightly builds on a dai
 
 Also, it is important that builds are tested by people outside the localization team. Ask other people from your community to help test in order to have fresh eyes looking at your work.
 
-l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [the Discourse Localization category](https://discourse.mozilla.org/c/l10n/). Please make sure you’re following this category closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.
+l10n-drivers send out regular reminders about merge days, updates on Android projects, schedule and important info on [the Discourse Localization category](https://discourse.mozilla.org/c/l10n/). Please make sure you’re following this category closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.

--- a/src/products/firefox_ios/adding_new_ios_locale.md
+++ b/src/products/firefox_ios/adding_new_ios_locale.md
@@ -20,4 +20,4 @@ For Pontoon, go to the [Firefox for iOS project page here](https://pontoon.mozil
 
 Once pending localization work is complete for a given release, l10n-drivers will work on adding the locale to [the list of shipping locales](https://github.com/mozilla-mobile/firefox-ios/blob/master/shipping_locales.txt).
 
-Remember to regularly check the [Discourse Localization channel](https://discourse.mozilla.org/c/l10n/) for latest information and updates on the project.
+Remember to regularly check the [Discourse Localization category](https://discourse.mozilla.org/c/l10n/) for latest information and updates on the project.

--- a/src/products/firefox_ios/adding_new_ios_locale.md
+++ b/src/products/firefox_ios/adding_new_ios_locale.md
@@ -10,14 +10,6 @@ Note that for Tier 2 locales, some menu items in Firefox for iOS can not be tran
 
 To tell if a locale is supported or not, take a look on an actual device, under the Language Settings of the most recent iOS version available. Tier one locales are the ones listed under “iPod/iPhone/iPad Language”, and Tier 2 locales appear under “Other Language” (or “Add Language” if there are already some languages under that list). If a locale appears under none of these two lists, then it should be safe to assume the language is not supported by iOS.
 
-### App Store language support
-
-The App Store only supports a subset of locales, compared to what the OS itself supports.
-
-This list is always growing. If translation work starts on Firefox for iOS for a locale that is supported by the App Store, it will automatically be enabled under the locale’s corresponding appstore’s folder (which can be found either in [Pontoon](https://pontoon.mozilla.org/projects/appstores/) or [GitHub](https://github.com/mozilla-l10n/appstores)).
-
-Note that App Store language support is not a requirement to translate the app itself. As long as a locale is supported by iOS (see point above), it’s possible to ship it.
-
 ## Request to add a localization
 
 Once it is determined if a locale is supported by the operating system and can ship on Firefox for iOS, a request can be made to work on the project through the usual localization tools.
@@ -28,4 +20,4 @@ For Pontoon, go to the [Firefox for iOS project page here](https://pontoon.mozil
 
 Once pending localization work is complete for a given release, l10n-drivers will work on adding the locale to [the list of shipping locales](https://github.com/mozilla-mobile/firefox-ios/blob/master/shipping_locales.txt).
 
-Remember to regularly check the [Firefox for iOS release schedule](https://wiki.mozilla.org/Firefox_for_iOS_Train_Schedule) as well as the [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n) for latest information and updates on the project.
+Remember to regularly check the [Discourse Localization channel](https://discourse.mozilla.org/c/l10n/) for latest information and updates on the project.

--- a/src/products/firefox_ios/testing.md
+++ b/src/products/firefox_ios/testing.md
@@ -1,6 +1,6 @@
 # Testing on iOS for a new release
 
-Localizers currently mostly rely on screenshots for testing. Latest information and updates about Firefox for iOS are generally announced on the [Discourse Localization channel](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on l10n for any of the existing Mozilla products.
+Localizers currently mostly rely on screenshots for testing. Latest information and updates about Firefox for iOS are generally announced on the [Discourse Localization category](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on l10n for any of the existing Mozilla products.
 
 ## Testing with screenshots
 

--- a/src/products/firefox_ios/testing.md
+++ b/src/products/firefox_ios/testing.md
@@ -1,10 +1,10 @@
 # Testing on iOS for a new release
 
-Localizers currently mostly rely on screenshots for testing. Latest information and updates about testing are provided on the [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n), which you should follow if you are working on l10n for any of the existing Mozilla products.
+Localizers currently mostly rely on screenshots for testing. Latest information and updates about Firefox for iOS are generally announced on the [Discourse Localization channel](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on l10n for any of the existing Mozilla products.
 
 ## Testing with screenshots
 
-Screenshots are currently provided by the iOS team, and the latest iterations can be found [right here](https://drive.google.com/drive/folders/1VOq91kGIm0XuneKdSl48HCwTkwXCw_Ve).
+Screenshots are currently provided by the iOS team, and the latest iterations can be found [right here](https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.firefox-ios.l10n-screenshots.latest). Once you find your locale in the list, you should choose and download the .zip file that contains your locale code.
 
 ## Test builds
 
@@ -23,10 +23,6 @@ Here is a list of issues you should try to identify when testing the build:
 
 Concerning untranslated content: please note that we currently have two tiers of support in iOS. If your locale is only in the Tier 2 support list, then it sometimes happens that menu items, which are part of the OS itself, may not be localizable - and will therefore unfortunately appear in English on the final UI. To tell if a locale is supported or not, simply take a look on an actual device, under the Language Settings of the most recent iOS version available. Tier 1 locales are the ones listed under “iPod/iPhone/iPad Language”, and Tier 2 locales appear under “Other Language” (or “Add Language” if there are already some languages under that list).
 
-## Testing a brand new locale
+## Shipping a brand new locale
 
-When a locale is brand new, l10n-drivers and the localization team will work through Bugzilla to process sign-offs on l10n testing.
-
-The l10n Mobile Project Manager will open up a meta bug for this and attach all needed bugs under their corresponding component. Closing the bug as resolved-fixed will signal that a locale is signing off on testing, and good to go for release.
-
-Details concerning all this process are always announced on the [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n).
+The locale is tested and has reached 20% completion, we will add the locale to release builds.


### PR DESCRIPTION
* Updated links talking about mailing list
* Updated Firefox for Android information, since android-l10n mentions are now irrelevant
* Updated Firefox iOS info as well