### PR TITLE
Adding Focus docs back

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -13,6 +13,7 @@ How to localize and test Mozilla products:
 * [Firefox for desktop](products/firefox_desktop/).
 * [Firefox for Android](products/firefox_android/).
 * [Firefox for iOS](products/firefox_ios/).
+* [Focus for Android and iOS](products/focus/).
 * [Mozilla.org](products/mozilla_org/).
 
 ### Tools

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,7 +16,7 @@
         * [Adding a new locale](products/firefox_ios/adding_new_ios_locale.md)
         * [How to test](products/firefox_ios/testing.md)
     * [Focus](products/focus/README.md)
-            * [How to test](products/focus/testing_focus.md)
+        * [How to test](products/focus/testing_focus.md)
     * [Mozilla.org](products/mozilla_org/README.md)
         * [How to test](products/mozilla_org/testing.md)
     * [Testing localization of Mozilla projects](products/l10n_testing.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -15,6 +15,8 @@
     * [Firefox for iOS](products/firefox_ios/README.md)
         * [Adding a new locale](products/firefox_ios/adding_new_ios_locale.md)
         * [How to test](products/firefox_ios/testing.md)
+    * [Focus](products/focus/README.md)
+            * [How to test](products/focus/testing_focus.md)
     * [Mozilla.org](products/mozilla_org/README.md)
         * [How to test](products/mozilla_org/testing.md)
     * [Testing localization of Mozilla projects](products/l10n_testing.md)

--- a/src/products/README.md
+++ b/src/products/README.md
@@ -4,6 +4,7 @@ Documentation regarding testing and localization of the following products:
 * [Firefox for desktop](firefox_desktop/)
 * [Firefox for Android](firefox_android/)
 * [Firefox for iOS](firefox_ios/)
+* [Focus](focus/)
 * [Mozilla.org](mozilla_org/)
 
 Documentation about [testing localization of Mozilla projects](l10n_testing.md) in general.

--- a/src/products/focus/README.md
+++ b/src/products/focus/README.md
@@ -1,0 +1,4 @@
+# L10n and Focus for iOS and Android
+
+Some documentation specific for common tasks regarding Focus for iOS and Android:
+* [How to test Focus](testing_focus.md).

--- a/src/products/focus/testing_focus.md
+++ b/src/products/focus/testing_focus.md
@@ -6,17 +6,17 @@ Localizers currently mostly rely on screenshots for testing Focus for iOS. Lates
 Links to iOS screenshots are also provided under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page.
 For Focus Android and iOS, there are also links to testing builds, if and when those are currently available.
 
-## Testing with screenshots (currently available Focus for iOS only)
+## Testing with screenshots (currently available for Focus for iOS only)
 
 Screenshots are provided by the mobile teams for iOS and appear under the Resources section in Pontoon or in the l10n Discourse channel (see above point for more details).
 
 ## Test builds
 
-There are Nightly localized builds for Focus for Android, that are accessible by following [the instructions here](https://github.com/mozilla-mobile/focus-android/wiki/Release-tracks). There are other builds available too, but Nightly is preferred for testing localizations, since it is updated daily.
+There are a few iterations of Nightly localized builds being created for Focus for Android, but they are not updated daily yet. The link appears under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
 
-For Focus for iOS Nightly builds, check under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page - or reach out directly to the mobile project manager (currently delphine at mozilla dot com) to be added to the TestFlight system.
+For Focus for iOS Nightly builds, check as well under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page - or reach out directly to the mobile project manager (currently delphine at mozilla dot com) to be added to the TestFlight system.
 
-For Focus for iOS, please note an iOS device running v11.4 or above is needed. For Focus for Android, an Android device running 5.0 or above is needed.
+For Focus for iOS, please note an iOS device running v13.6 or above is needed. For Focus for Android, an Android device running v5.0 or above is needed.
 
 ## Aspects to review
 

--- a/src/products/focus/testing_focus.md
+++ b/src/products/focus/testing_focus.md
@@ -1,10 +1,10 @@
-# Testing on Focus for iOS and Focus for Android for a new release
+# Testing Focus for iOS and Focus for Android for a new release
 
-Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once.
+Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once. Please note that certain markets, the app is named Klar. For the sake of simplicity, we will only call out the name “Focus” in this document.
 
 Localizers currently mostly rely on screenshots for testing Focus for iOS. Latest information and updates about testing are provided on the [l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on localizing any of the existing Mozilla products.
 Links to iOS screenshots are also provided under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page.
-For Focus Android and iOS, there are also links to testing builds, if and when those are currently available.
+For Focus for Android and iOS, there are also links to testing builds, if they are currently available.
 
 ## Testing with screenshots (currently available for Focus for iOS only)
 
@@ -12,7 +12,7 @@ Screenshots are provided by the mobile teams for iOS and appear under the Resour
 
 ## Test builds
 
-There are a few iterations of Nightly localized builds being created for Focus for Android, but they are not updated daily yet. The link appears under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
+There are a few iterations of Nightly localized builds being created for Focus for Android, but they are not updated daily yet. The link appears under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/). At this point, they are not yet automatically updated once installed.
 
 For Focus for iOS Nightly builds, check as well under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page - or reach out directly to the mobile project manager (currently delphine at mozilla dot com) to be added to the TestFlight system.
 
@@ -32,12 +32,10 @@ Concerning untranslated content on Focus for iOS: please note that we currently 
 
 ## Locale sign-offs
 
-L10n-drivers and the localization team will work together to determine if a locale can ship or not, for each release.
-
-For mobile app projects (so all except Firefox for Android), all locales with complete translations and without errors on the [web dashboard](https://l10n.mozilla-community.org/webstatus/?product=focus-ios) at l10n deadline are considered for shipping. Additionally, they must have no visible l10n errors upon review of the locale’s screenshots (e.g., significant truncation, text overflow, encoding, etc.) besides what
-may have already been reported to the mobile team to correct.
+Unless there are visible l10n errors upon review of the locale’s screenshots (e.g., significant truncation, text overflow, encoding, etc.) - and besides what
+may have already been reported to the mobile team to correct - we will ship any locale that has started to localize (this applies to both Focus products).
 
 Focus for Android issues [can be filed here](https://github.com/mozilla-mobile/focus-android/issues/).<br/>
 Focus for iOS issues [can be filed here](https://github.com/mozilla-mobile/focus-ios/issues).
 
-Details concerning all this process are always announced on the [[l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/).
+Details concerning any major updates concerning these products are always announced on the [[l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/) - and reflected in this document as well.

--- a/src/products/focus/testing_focus.md
+++ b/src/products/focus/testing_focus.md
@@ -2,21 +2,21 @@
 
 Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once.
 
-Localizers currently mostly rely on screenshots for testing. Latest information and updates about testing are provided on the [dev-l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n), which you should follow if you are working on l10n for any of the existing Mozilla products.
+Localizers currently mostly rely on screenshots for testing Focus for iOS. Latest information and updates about testing are provided on the [l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on localizing any of the existing Mozilla products.
+Links to iOS screenshots are also provided under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page.
+For Focus Android and iOS, there are also links to testing builds, if and when those are currently available.
 
-## Testing with screenshots
+## Testing with screenshots (currently available Focus for iOS only)
 
-Screenshots are provided by the mobile teams and sent out through Pontoon notifications.
+Screenshots are provided by the mobile teams for iOS and appear under the Resources section in Pontoon or in the l10n Discourse channel (see above point for more details).
 
 ## Test builds
 
 There are Nightly localized builds for Focus for Android, that are accessible by following [the instructions here](https://github.com/mozilla-mobile/focus-android/wiki/Release-tracks). There are other builds available too, but Nightly is preferred for testing localizations, since it is updated daily.
 
-Note that for those who do not wish to use Google Play, there are also Nightly builds available on [Taskcluster here](https://tools.taskcluster.net/index/project.mobile.focus.nightly/latest). The build to download is the APK file containing "universal-release" in the name.
+For Focus for iOS Nightly builds, check under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page - or reach out directly to the mobile project manager (currently delphine at mozilla dot com) to be added to the TestFlight system.
 
-For Focus for iOS Nightly builds, reach out to the mobile project manager (currently delphine at mozilla dot com) to be added to the BuddyBuild system.
-
-For Focus for iOS, please note an iOS device running v9 or above is needed. For Focus for Android, an Android device running 5.0 or above is needed.
+For Focus for iOS, please note an iOS device running v11.4 or above is needed. For Focus for Android, an Android device running 5.0 or above is needed.
 
 ## Aspects to review
 
@@ -40,4 +40,4 @@ may have already been reported to the mobile team to correct.
 Focus for Android issues [can be filed here](https://github.com/mozilla-mobile/focus-android/issues/).<br/>
 Focus for iOS issues [can be filed here](https://github.com/mozilla-mobile/focus-ios/issues).
 
-Details concerning all this process are always announced on the [dev-l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n).
+Details concerning all this process are always announced on the [[l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/).

--- a/src/products/focus/testing_focus.md
+++ b/src/products/focus/testing_focus.md
@@ -1,0 +1,43 @@
+# Testing on Focus for iOS and Focus for Android for a new release
+
+Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once.
+
+Localizers currently mostly rely on screenshots for testing. Latest information and updates about testing are provided on the [dev-l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n), which you should follow if you are working on l10n for any of the existing Mozilla products.
+
+## Testing with screenshots
+
+Screenshots are provided by the mobile teams and sent out through Pontoon notifications.
+
+## Test builds
+
+There are Nightly localized builds for Focus for Android, that are accessible by following [the instructions here](https://github.com/mozilla-mobile/focus-android/wiki/Release-tracks). There are other builds available too, but Nightly is preferred for testing localizations, since it is updated daily.
+
+Note that for those who do not wish to use Google Play, there are also Nightly builds available on [Taskcluster here](https://tools.taskcluster.net/index/project.mobile.focus.nightly/latest). The build to download is the APK file containing "universal-release" in the name.
+
+For Focus for iOS Nightly builds, reach out to the mobile project manager (currently delphine at mozilla dot com) to be added to the BuddyBuild system.
+
+For Focus for iOS, please note an iOS device running v9 or above is needed. For Focus for Android, an Android device running 5.0 or above is needed.
+
+## Aspects to review
+
+Here is a list of issues you should try to identify when testing the build:
+* Language quality.
+* Truncated words (cut-off from screen).
+* Anything that appears broken on the UI.
+* Check out all the main screens, UI, menus, tabs, new features, etc. Make sure these all look good, that everything is properly translated and appears as expected.
+* Font support: once you start translating, you should check against the screenshots provided that the fonts used appear correctly.
+* Untranslated content.
+
+Concerning untranslated content on Focus for iOS: please note that we currently have two tiers of support in iOS. If your locale is only in the Tier 2 support (which corresponds to the languages under *Other Languages* in the iOS system settings), then it sometimes happens that menu items and dialogs, which are part of the OS itself, may not be localizable - and will therefore unfortunately appear in the primary OS language on the final UI.
+
+## Locale sign-offs
+
+L10n-drivers and the localization team will work together to determine if a locale can ship or not, for each release.
+
+For mobile app projects (so all except Firefox for Android), all locales with complete translations and without errors on the [web dashboard](https://l10n.mozilla-community.org/webstatus/?product=focus-ios) at l10n deadline are considered for shipping. Additionally, they must have no visible l10n errors upon review of the locale’s screenshots (e.g., significant truncation, text overflow, encoding, etc.) besides what
+may have already been reported to the mobile team to correct.
+
+Focus for Android issues [can be filed here](https://github.com/mozilla-mobile/focus-android/issues/).<br/>
+Focus for iOS issues [can be filed here](https://github.com/mozilla-mobile/focus-ios/issues).
+
+Details concerning all this process are always announced on the [dev-l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n).

--- a/src/products/focus/testing_focus.md
+++ b/src/products/focus/testing_focus.md
@@ -1,6 +1,6 @@
 # Testing Focus for iOS and Focus for Android for a new release
 
-Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once. Please note that certain markets, the app is named Klar. For the sake of simplicity, we will only call out the name “Focus” in this document.
+Given Focus for iOS and Focus for Android have very similar test procedures, this document will cover both at once. Please note that in certain markets, the app is named “Klar”. For the sake of simplicity, we will only call out the name “Focus” in this document.
 
 Localizers currently mostly rely on screenshots for testing Focus for iOS. Latest information and updates about testing are provided on the [l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/), which you should follow if you are working on localizing any of the existing Mozilla products.
 Links to iOS screenshots are also provided under the Resources section [in Pontoon](https://pontoon.mozilla.org/projects/focus-for-ios/), at the top of the project page.
@@ -38,4 +38,4 @@ may have already been reported to the mobile team to correct - we will ship any 
 Focus for Android issues [can be filed here](https://github.com/mozilla-mobile/focus-android/issues/).<br/>
 Focus for iOS issues [can be filed here](https://github.com/mozilla-mobile/focus-ios/issues).
 
-Details concerning any major updates concerning these products are always announced on the [[l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/) - and reflected in this document as well.
+Details about any major updates concerning these products are always announced on the [[l10n Discourse Channel](https://discourse.mozilla.org/c/l10n/) - and are reflected in this document as well.

--- a/src/products/l10n_testing.md
+++ b/src/products/l10n_testing.md
@@ -130,5 +130,6 @@ For project-specific testing guides, please see these pages:
 * [Firefox Desktop](../products/firefox_desktop/testing.md).
 * [Firefox for Android](../products/firefox_android/testing.md).
 * [Firefox for iOS](../products/firefox_ios/testing.md).
+* [Focus](../products/focus/testing_focus.md).
 * [Mozilla.org](../products/mozilla_org/testing.md).
 * [Support.mozilla.org (SUMO)](../webprojects/sumo.md).


### PR DESCRIPTION
Based myself on the latest commit concerning removing Focus docs, based on this commit: https://github.com/mozilla-l10n/localizer-documentation/commit/047c754d9795ffe9953fb3b08011fe9d4e0865f9
Now going to update the documentation where needed