### PR TITLE
Pontoon documentation: Unify style for on screen text, usage of italics, other improvements

### DIFF
--- a/src/tools/pontoon/README.md
+++ b/src/tools/pontoon/README.md
@@ -1,6 +1,8 @@
 # How to use Pontoon
 
-This document covers how to work with [Pontoon](https://pontoon.mozilla.org/) from the user’s perspective, and use it to localize Mozilla projects online. If you’re interested in administrating Pontoon, please read [these documents](https://mozilla-l10n.github.io/documentation/tools/pontoon/index.html).
+This document covers how to work with [Pontoon](https://pontoon.mozilla.org/) from the user’s perspective. While most of the documentation applies to any deployment of Pontoon, the Mozilla instance is referenced frequently as an example. Some limited portions apply specifically to using Pontoon to localize Mozilla projects online.
+
+If you’re interested in administrating Pontoon, please read [these documents](https://mozilla-l10n.github.io/documentation/tools/pontoon/index.html).
 
 * [User accounts and settings](users.md).
 * [Profile page](profile.md).

--- a/src/tools/pontoon/glossary.md
+++ b/src/tools/pontoon/glossary.md
@@ -37,7 +37,7 @@ Users in Pontoon can have different permissions depending on their role:
 
 ## Resource
 
-Resources are localization files within a repository (see [version control system](#version-control-system)) used to store source content and translations. They can be in different file formats but generally follow the same key-value structure, where the key (displayed as *Context* in the Source string panel) is a unique identifier and the value is a text snippet that needs to be translated.
+Resources are localization files within a repository (see [version control system](#version-control-system)) used to store source content and translations. They can be in different file formats but generally follow the same key-value structure, where the key (displayed as `Context` in the Source string panel) is a unique identifier and the value is a text snippet that needs to be translated.
 
 ## Terminology
 

--- a/src/tools/pontoon/profile.md
+++ b/src/tools/pontoon/profile.md
@@ -28,4 +28,4 @@ By default, the chart will show data for **all contributions** over the last yea
 * Reviews received.
 * Submissions and reviews.
 
-The *activity log* below this chart will display the user’s activity in more detail for the last month. Clicking on a specific square (day) in the chart will only show the activity for that day. Each line item in the activity log is a link that allows to jump to those specific strings in the translation editor.
+The activity log below this chart will display the user’s activity in more detail for the last month. Clicking on a specific square (day) in the chart will only show the activity for that day. Each line item in the activity log is a link that allows to jump to those specific strings in the translation editor.

--- a/src/tools/pontoon/search_filters.md
+++ b/src/tools/pontoon/search_filters.md
@@ -38,9 +38,9 @@ Filters can be accessed by clicking the icon on the left of the search field.
 ![Filters](../../assets/images/pontoon/search_filters/filters.png)
 
 At this point it’s possible to:
-* Click directly on the name of one of the filters. This will select and activate only this filter, and the search field placeholder will change accordingly. For example, clicking on *Missing* will show only missing strings, and the placeholder will read *Search in Missing*.
-* Click on one or more filter icons or user avatars (multiple filters can be applied at once). Hovering over the icons transforms the icon into check marks. Clicking an icon will select that filter and a new button *APPLY X FILTERS* will appear at the bottom of the panel, where `X` is the number of active filters.
-* Click *EDIT RANGE* on `TRANSLATION TIME` to select a **time range**. Pick one of the defaults (30 days, 7 days, 24 hours, 60 minutes), or use the date picker (or slider) to adapt the range. Click on *SAVE RANGE* to store the range as a filter. A new button *APPLY X FILTERS* will appear at the bottom of the panel, where `X` is the number of active filters.
+* Click directly on the name of one of the filters. This will select and activate only this filter, and the search field placeholder will change accordingly. For example, clicking on `Missing` will show only missing strings, and the placeholder will read `Search in Missing`.
+* Click on one or more filter icons or user avatars (multiple filters can be applied at once). Hovering over the icons transforms the icon into check marks. Clicking an icon will select that filter and a new button `APPLY X FILTERS` will appear at the bottom of the panel, where `X` is the number of active filters.
+* Click `EDIT RANGE` on `TRANSLATION TIME` to select a time range. Pick one of the defaults (30 days, 7 days, 24 hours, 60 minutes), or use the date picker (or slider) to adapt the range. Click on `SAVE RANGE` to store the range as a filter. A new button `APPLY X FILTERS` will appear at the bottom of the panel, where `X` is the number of active filters.
 
 ![Multiple filters](../../assets/images/pontoon/search_filters/filters_multiple.png)
 

--- a/src/tools/pontoon/search_filters.md
+++ b/src/tools/pontoon/search_filters.md
@@ -17,21 +17,21 @@ To search for an exact match, wrap the search terms in double quotes, e.g. `"new
 ### Translation status
 
 Strings in Pontoon can be filtered by their status. A string can be in one of the following statuses:
-* *Translated*: string has an approved translation. The translation is saved to the localized file when using a [version control system](glossary.md#version-control-system) (VCS).
-* *Pretranslated*: string has been pretranslated but has not been reviewed. Unreviewed pretranslation are saved to the localized file when using a VCS.
-* *Warnings*: string contains issues classified as [warnings](translate.md#warnings).
-* *Errors*: string contains [critical issues](translate.md#errors).
-* *Missing*: string doesn’t have any approved translations.
-* *Unreviewed*: string has suggested translations that have not been reviewed yet by someone with the appropriate [permissions](glossary.md#permission). Note that, for both translated and missing strings, the suggested translation only exists within the Pontoon database and is not saved to the localized file when using a VCS.
+* **Translated**: string has an approved translation. The translation is saved to the localized file when using a [version control system](glossary.md#version-control-system) (VCS).
+* **Pretranslated**: string has been pretranslated but has not been reviewed. Unreviewed pretranslation are saved to the localized file when using a VCS.
+* **Warnings**: string contains issues classified as [warnings](translate.md#warnings).
+* **Errors**: string contains [critical issues](translate.md#errors).
+* **Missing**: string doesn’t have any approved translations.
+* **Unreviewed**: string has suggested translations that have not been reviewed yet by someone with the appropriate [permissions](glossary.md#permission). Note that, for both translated and missing strings, the suggested translation only exists within the Pontoon database and is not saved to the localized file when using a VCS.
 
 ### Extra filters
 
 In addition to statuses, additional filters can be used to further refine the list of strings. Extra filters include:
-* *Unchanged*: string is identical to the reference language (normally `en-US`).
-* *Empty*: string has a translation, but translation contains no content.
-* *Fuzzy*: string is marked as [fuzzy](glossary.md#fuzzy) in the localized file.
-* *Rejected*: string has rejected translations.
-* *Missing without Unreviewed*: string has `Missing` translation status and does not have `Unreviewed` translations.
+* **Unchanged**: string is identical to the reference language (normally `en-US`).
+* **Empty**: string has a translation, but translation contains no content.
+* **Fuzzy**: string is marked as [fuzzy](glossary.md#fuzzy) in the localized file.
+* **Rejected**: string has rejected translations.
+* **Missing without Unreviewed**: string has `Missing` translation status and does not have `Unreviewed` translations.
 
 Filters can be accessed by clicking the icon on the left of the search field.
 

--- a/src/tools/pontoon/teams_projects.md
+++ b/src/tools/pontoon/teams_projects.md
@@ -2,13 +2,13 @@
 
 <!-- toc -->
 
-The *Teams page*, accessible using the `/teams` URL (e.g. [pontoon.mozilla.org/teams](https://pontoon.mozilla.org/teams/)), lists all locales that are enabled in Pontoon. From here it’s possible to access a specific [Team page](#team-page), which contains a list of all projects enabled for the requested locale. Selecting a project from the *Team page* leads to the so-called the [Localization page](#localization-page).
+The Teams page, accessible using the `/teams` URL (e.g. [pontoon.mozilla.org/teams](https://pontoon.mozilla.org/teams/)), lists all locales that are enabled in Pontoon. From here it’s possible to access a specific [Team page](#team-page), which contains a list of all projects enabled for the requested locale. Selecting a project from the Team page leads to the so-called the [Localization page](#localization-page).
 
-From each locale’s *Team page* it’s also possible to [Request a project](#requesting-a-project). Note that this is a request to add the locale to a project already available in Pontoon, it can’t be used for requesting a brand new project.
+From each locale’s Team page it’s also possible to [Request a project](#requesting-a-project). Note that this is a request to add the locale to a project already available in Pontoon, it can’t be used for requesting a brand new project.
 
-The *Projects page*, accessible using the `/projects` URL (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/projects/)), lists all projects that are available in Pontoon. From here it’s possible to access a [Project page](#project-page), which shows all locales that are enabled for the requested project. Selecting a locale in the *Project page* leads to the [Localization page](#localization-page).
+The Projects page, accessible using the `/projects` URL (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/projects/)), lists all projects that are available in Pontoon. From here it’s possible to access a [Project page](#project-page), which shows all locales that are enabled for the requested project. Selecting a locale in the Project page leads to the [Localization page](#localization-page).
 
-There is also a special *Localization page* that allows access to all resources for all projects enabled for a specific locale: `/locale/all-projects/all-resources`.
+There is also a special Localization page that allows access to all resources for all projects enabled for a specific locale: `/locale/all-projects/all-resources`.
 
 The following diagram shows how these pages are organized and connected to each other:
 
@@ -18,28 +18,28 @@ The following diagram shows how these pages are organized and connected to each 
 
 ### Teams page
 
-The *Teams page* lists all locales that are enabled in Pontoon. It can be reached by clicking `Teams` in the page header (not displayed when translating a project) or by using the `/teams` URL (e.g. [pontoon.mozilla.org/teams](https://pontoon.mozilla.org/teams/)). Clicking on a specific locale will open the locale’s [Team page](#team-page).
+The Teams page lists all locales that are enabled in Pontoon. It can be reached by clicking `Teams` in the page header (not displayed when translating a project) or by using the `/teams` URL (e.g. [pontoon.mozilla.org/teams](https://pontoon.mozilla.org/teams/)). Clicking on a specific locale will open the locale’s [Team page](#team-page).
 
 ### Team page
 
-Access a specific team’s page by selecting it from the *Teams page* or by appending a locale code to the end of the Pontoon base URL with `/{LOCALE}` (e.g [pontoon.mozilla.org/it](https://pontoon.mozilla.org/it) for Italian). This page shows a list of all projects enabled for the locale. Clicking on one of these projects leads to the [Localization page](#localization-page).
+Access a specific team’s page by selecting it from the Teams page or by appending a locale code to the end of the Pontoon base URL with `/{LOCALE}` (e.g [pontoon.mozilla.org/it](https://pontoon.mozilla.org/it) for Italian). This page shows a list of all projects enabled for the locale. Clicking on one of these projects leads to the [Localization page](#localization-page).
 
-The page header contains linguistic information about the current locale (plural form, writing direction, etc.), plus an indication of the overall status of completion and statistics. The statistics displayed in the rightmost column are active links to access the *Localization page* for all projects. For example, select `MISSING` to see all missing strings across projects enabled for that locale in Pontoon.
+The page header contains linguistic information about the current locale (plural form, writing direction, etc.), plus an indication of the overall status of completion and statistics. The statistics displayed in the rightmost column are active links to access the Localization page for all projects. For example, select `MISSING` to see all missing strings across projects enabled for that locale in Pontoon.
 
 ![Header of team page for Italian](../../assets/images/pontoon/teams_projects/team_page_header.png)
 
-There are up to 5 tabs available to all [roles](users.md#user-roles), and 1 additional tab for those with *Administrator* or *Team manager* roles:
+There are up to 5 tabs available to all [roles](users.md#user-roles), and 1 additional tab for those with Administrator or Team manager roles:
 
 * **Projects**: a list of all projects enabled in Pontoon for this locale.
 * **Contributors**: a list of active contributors with their statistics, filterable by time (all time, last 12/6/3/1 months).
 * [**Insights**](#insights-graphs): contains data and trends presented in a graphical format about active users, time to review suggestions, review activity, and translation activity.
 * **Bugs**: a list of open bugs for this locale, retrieved from [Bugzilla](https://bugzilla.mozilla.org/). Note this is specific to Mozilla’s deployment of Pontoon.
-* **Info**: information about the team. *Team managers* can edit this by clicking on the `EDIT` button.
+* **Info**: information about the team. Team managers can edit this by clicking on the `EDIT` button.
 * **Permissions**: [manage user permissions](users.md#managing-permissions).
 
 The labels and icon in the table header can be used to sort the list of projects. For example, clicking on `Priority` will sort based on project priority.
 
-Hovering a project in the *Projects* list will replace the progress bar with a set of detailed statistics (untranslated strings, missing strings, etc.). Note that all these numbers are links, use them to open the project with a filter already enabled, for example to display only missing strings. Clicking `ALL` accesses *All Resources* (i.e. all strings in all files) for this project.
+Hovering a project in the Projects list will replace the progress bar with a set of detailed statistics (untranslated strings, missing strings, etc.). Note that all these numbers are links, use them to open the project with a filter already enabled, for example to display only missing strings. Clicking `ALL` accesses All Resources (i.e. all strings in all files) for this project.
 
 The rightmost column in the table will display a blue lightbulb icon if there are unreviewed translations. Note: clicking the lightbulb icon in the table header can be used to sort projects based on the number of unreviewed translations.
 
@@ -47,13 +47,13 @@ The rightmost column in the table will display a blue lightbulb icon if there ar
 
 ### Requesting a project
 
-It’s possible to request a project from a *Team page*. Note that this is a request to add the locale to a project already available in Pontoon, it can’t be used for requesting a brand new project.
+It’s possible to request a project from a Team page. Note that this is a request to add the locale to a project already available in Pontoon, it can’t be used for requesting a brand new project.
 
 ![Request a project](../../assets/images/pontoon/teams_projects/request_project.png)
 
 Click on `REQUEST MORE PROJECTS`, select the project to add and then click `REQUEST NEW PROJECT` (at least one project needs to be selected for the button to be displayed).
 
-An email will be sent to Pontoon’s administrators, and the *Project manager* in charge of the project will act on the request. Please note that:
+An email will be sent to Pontoon’s administrators, and the Project manager in charge of the project will act on the request. Please note that:
 * Some projects have a closed list of supported locales, meaning that these projects can’t be requested on Pontoon.
 * Some projects can be requested but may not be enabled for practical restrictions related to the project itself (e.g. lack of support for the locale in iOS).
 
@@ -61,24 +61,24 @@ An email will be sent to Pontoon’s administrators, and the *Project manager* i
 
 ### Projects page
 
-The *Projects page* lists all projects that are available in Pontoon. It can be reached by clicking `Projects` in the page header (not displayed when translating a project) or by using the `/projects` URL (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/teams/)). Clicking on a specific [Project page](#project-page) will open the project’s [Project page](#project-page).
+The Projects page lists all projects that are available in Pontoon. It can be reached by clicking `Projects` in the page header (not displayed when translating a project) or by using the `/projects` URL (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/teams/)). Clicking on a specific [Project page](#project-page) will open the project’s [Project page](#project-page).
 
 ### Project page
 
-Access a project’s page by selecting it from the *Projects page* (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/projects/)). This page shows a list of all locales enabled for the project. Clicking on one of these locales leads to the [Localization page](#localization-page).
+Access a project’s page by selecting it from the Projects page (e.g. [pontoon.mozilla.org/projects](https://pontoon.mozilla.org/projects/)). This page shows a list of all locales enabled for the project. Clicking on one of these locales leads to the [Localization page](#localization-page).
 
 The page header contains useful information about the current project:
 * **Priority**: priority from 5 stars (highest) to 1 star (lowest).
 * **Target date**: set only for some projects, it indicates when the translation is due.
 * **Repository**: link to the repository storing translations for this project.
-* **Resources**: links to useful external resources (e.g. testing instructions, screenshots, etc.). *Project managers* can set up custom links for each project.
+* **Resources**: links to useful external resources (e.g. testing instructions, screenshots, etc.). Project managers can set up custom links for each project.
 * **Project manager**: point of contact for this project.
 
 It also includes an indication of the overall status of completion and statistics across all enabled languages.
 
 ![Header of project page for Mozilla.org](../../assets/images/pontoon/teams_projects/project_page_header.png)
 
-There are up to 5 tabs available to all [roles](users.md#user-roles), and 1 additional tab for those with *Administrator* roles:
+There are up to 5 tabs available to all [roles](users.md#user-roles), and 1 additional tab for those with Administrator roles:
 
 * **Teams**: a list of all locales enabled in Pontoon for this project.
 * **Tags**: a list of tags defined for this project. This tab will be visible only in projects where tags are enabled. For more information about tags, see [this page](search_filters.md#tags).
@@ -89,17 +89,17 @@ There are up to 5 tabs available to all [roles](users.md#user-roles), and 1 addi
 
 ### Requesting a locale
 
-It’s possible to request an additional locale for some projects from its *Project page*.
+It’s possible to request an additional locale for some projects from its Project page.
 
 ![Request a project](../../assets/images/pontoon/teams_projects/request_locale.png)
 
 Click on `REQUEST NEW LANGUAGE`, select the locale to add and then click `REQUEST NEW LANGUAGE`.
 
-An email will be sent to Pontoon’s administrators, and the *Project manager* in charge of the project will act on the request. The same restrictions described in the [Requesting a project](#requesting-a-project) section apply here.
+An email will be sent to Pontoon’s administrators, and the Project manager in charge of the project will act on the request. The same restrictions described in the [Requesting a project](#requesting-a-project) section apply here.
 
 ## Localization page
 
-Access a project’s *Localization page* in two ways:
+Access a project’s Localization page in two ways:
 * By selecting it from the [Team page](#team-page).
 * By selecting it from the [Project page](#project-page).
 
@@ -110,24 +110,24 @@ The page header contains useful information about the current project (same as t
 There are 6 tabs available:
 * **Resources**: files available in the project.
 * **Tags**: a list of tags defined for this project. This tab will be visible only in projects where tags are enabled. For more information about tags, see [this page](search_filters.md#tags).
-* **Contributors**: a list of active contributors with their statistics, filterable by time. Unlike the tab available in the *Team page*, this only includes contributions to localization of the project for the current locale.
+* **Contributors**: a list of active contributors with their statistics, filterable by time. Unlike the tab available in the Team page, this only includes contributions to localization of the project for the current locale.
 * [**Insights**](#insights-graphs): contains data and trends presented in a graphical format about review activity and translation activity.
 * **Project info**: information about the project.
-* **Team info**: same content as the *Info* tab in the *Team page*.
+* **Team info**: same content as the Info tab in the Team page.
 
-In addition to the *Localization page* for each locale/project pair, there is also a special *Localization page* that allows access to all resources for all projects enabled for a specific locale. This can be accessed from the `/{LOCALE}/all-projects/all-resources` URL (e.g. [pontoon.mozilla.org/it/all-projects/all-resources](https://pontoon.mozilla.org/it/all-projects/all-resources) for Italian).
+In addition to the Localization page for each locale/project pair, there is also a special Localization page that allows access to all resources for all projects enabled for a specific locale. This can be accessed from the `/{LOCALE}/all-projects/all-resources` URL (e.g. [pontoon.mozilla.org/it/all-projects/all-resources](https://pontoon.mozilla.org/it/all-projects/all-resources) for Italian).
 
 ## Insights graphs
 
-The *Insights tab*, accessible from either the *Project*, *Team*, or *Localization page*, displays data and trends on contributor and localization activity in a graphical format.
+The Insights tab, accessible from either the Project, Team, or Localization page, displays data and trends on contributor and localization activity in a graphical format.
 
 The following insights appear on all pages:
-* **Review activity**: shows the number of unreviewed suggestions as a trend line. The *Team page* also shows the number of peer-approved, self-approved, and rejected suggestions for each month as a bar graph to display the impact of the review process on the number of unreviewed suggestions. *New suggestions* (hidden by default) can also be shown by clicking `New suggestions` at the bottom of the graph. Hover over a data point to get the detailed number of strings and percentages for that month.
-* **Translation activity**: shows the translation completion percentage for the locale as a trend line. The *Team page* also shows the number of human translations and [machinery translations](ui.md#machinery) for each month as a bar graph to display the impact of the translation process on the number of completed translations. *New source strings* (hidden by default) can also be shown by clicking `New source strings` at the bottom of the graph. Hover over a data point to get the detailed number of strings and percentages for that month.
+* **Review activity**: shows the number of unreviewed suggestions as a trend line. The Team page also shows the number of peer-approved, self-approved, and rejected suggestions for each month as a bar graph to display the impact of the review process on the number of unreviewed suggestions. New suggestions (hidden by default) can also be shown by clicking `New suggestions` at the bottom of the graph. Hover over a data point to get the detailed number of strings and percentages for that month.
+* **Translation activity**: shows the translation completion percentage for the locale as a trend line. The Team page also shows the number of human translations and [machinery translations](ui.md#machinery) for each month as a bar graph to display the impact of the translation process on the number of completed translations. New source strings (hidden by default) can also be shown by clicking `New source strings` at the bottom of the graph. Hover over a data point to get the detailed number of strings and percentages for that month.
 
-The following insights only appear on *Team pages*:
+The following insights only appear on Team pages:
 * **Active users**: shows the ratio of active versus total for each [user role](users.md#user-roles): managers (Team managers), reviewers (Team managers and Translators), and contributors, filterable by time period (last 12/6/3/1 months).
 * **Time to review suggestions**: shows the average age of [suggestions](glossary.md#translation) reviewed for a particular month, and the 12 month average. Hover over a data point in the graph to see the exact age in days for that month’s current and 12 month average.
-* **Age of unreviewed suggestions**: this can be accessed by clicking `Age of unreviewed` on the bottom of the *Time to review suggestions* graph. Shows the average age of unreviewed suggestions at a particular point in time. Hover over a data point in the graph to see the exact age in days for unreviewed suggestions for that month.
+* **Age of unreviewed suggestions**: this can be accessed by clicking `Age of unreviewed` on the bottom of the Time to review suggestions graph. Shows the average age of unreviewed suggestions at a particular point in time. Hover over a data point in the graph to see the exact age in days for unreviewed suggestions for that month.
 
 Note: clicking on the `i` icon in the top right of each insight will provide detailed definitions for the data shown.

--- a/src/tools/pontoon/translate.md
+++ b/src/tools/pontoon/translate.md
@@ -6,7 +6,7 @@ This document describes briefly how to translate and review strings in Pontoon. 
 
 When a string is selected in the sidebar, users can input a translation using the editor available in the middle of the page. Note that, if the string already has a [translation](glossary.md#translation), the editor will be pre-populated with text that the user can modify.
 
-Depending on the current translation mode, the UI will look slightly different.
+Depending on the current [translation mode](glossary.md#translation-mode), the UI will look slightly different.
 
 When the user is in *Suggestion Mode* — [manually selected](#manually-switch-to-suggestion-mode), or because the user doesn’t have permissions to submit translations directly — a blue `SUGGEST` button will be displayed in the lower-right side of the editing space.
 

--- a/src/tools/pontoon/ui.md
+++ b/src/tools/pontoon/ui.md
@@ -3,9 +3,9 @@
 <!-- toc -->
 
 Pontoon’s translation workspace consists of the main toolbar and 3 columns:
-* The left column includes a list of strings with a search field at the top.
-* The main editing space is located in the middle column.
-* The right column includes information about terminology, source string comments, suggestions from translation memory, machine translation, and other locales.
+* The left column contains the string list for the current resource with a search field at the top.
+* The middle column contains the main editing space.
+* The right column contains terminology, source string comments, suggestions from translation memory, machine translation, and translations from other locales.
 
 ![Translation Workspace](../../assets/images/pontoon/ui/translation_workspace.png "Screenshot of the translation workspace in Pontoon")
 
@@ -34,7 +34,7 @@ Note that some profile menu items are only available to users with specific [per
 ## String list and filters
 
 The left column displays the list of strings in the current project resource. Each string is represented by:
-* A colored square that identifies the string status (i.e. *Missing*, *Translated*, etc.).
+* A colored square that identifies the string [status](search_filters.md#translation-status) (i.e. *Missing*, *Translated*, etc.).
 * The source string.
 * The approved translation or the most recent suggestion if available.
 
@@ -47,7 +47,7 @@ Color legend:
 * **<span style="color: #ffa10f;">orange</span>**: translation has warnings.
 * **<span style="color: #f36;">red</span>**: translation has errors.
 
-When a string is selected in the sidebar, a small icon with 4 arrows is displayed near the checkbox: this can be used to show strings that surround the selected string in the [resource](glossary.md#resource), bypassing the current filter. This is often helpful to provide more context for the localization, especially when translating missing strings.
+When a string is selected in the sidebar, a small icon with four arrows is displayed near the checkbox: this can be used to show strings that surround the selected string in the [resource](glossary.md#resource), bypassing the current filter. This is often helpful to provide more context for the localization, especially when translating missing strings.
 
 ![Button to show sibling strings in sidebar](../../assets/images/pontoon/ui/sidebar_expand.png "Screenshot of the button to show sibling strings in sidebar")
 
@@ -81,7 +81,7 @@ In the lower-left side:
 
 #### Read-only projects
 
-A project could be enabled in *read-only* mode for some locales: their translations will be available to other languages in the `LOCALES` tab, but it won’t be possible to change or submit translations directly in Pontoon. In this case, a note is displayed in the bar below the editor, and all other controls are hidden.
+A project could be enabled in *read-only mode* for some locales: their translations will be available to other languages in the `LOCALES` tab, but it won’t be possible to change or submit translations directly in Pontoon. In this case, a note is displayed in the bar below the editor, and all other controls are hidden.
 
 ![Translation editor in read-only project](../../assets/images/pontoon/ui/translation_readonly.png "Screenshot of translation editor in read-only project")
 
@@ -96,7 +96,7 @@ Each entry contains:
 * Icons indicating translation status (see below).
 * [Translation comments](glossary.md#comment).
 
-Icons to the right indicate the status of each translation:
+Icons to the right indicate the [status](search_filters.md#translation-status) of each translation:
 * The solid green circle with checkmark indicates that the translation has been approved.
 * The outlined lime green circle with checkmark indicates a pretranslation that has not yet been reviewed.
 * If both icons are gray, translation has been suggested but not yet reviewed.
@@ -105,7 +105,7 @@ Icons to the right indicate the status of each translation:
 
 ![List of suggestions and translations for a string](../../assets/images/pontoon/ui/translation_comments.png "Screenshot of list of suggestions and translations for a string with comment editing open")
 
-In the screenshot above, the first item is the approved translation (green checkmark), while the other 2 are rejected suggestions. By clicking the `COMMENT` button it’s possible to add a **translation comment** to this specific translation. To mention another user in the comment, start typing `@` followed by their name.
+In the screenshot above, the first item is the approved translation (green checkmark), while the other two are rejected suggestions. By clicking the `COMMENT` button it’s possible to add a **translation comment** to this specific translation. To mention another user in the comment, start typing `@` followed by their name.
 
 If there is already a comment associated with a string, the button will display the number of comments (e.g. `1 COMMENT` for the first rejected suggestion).
 
@@ -123,7 +123,7 @@ When working on FTL (Fluent) files, the editing space will look slightly differe
 
 In the example above, the string has a `value` and an attribute `title`. Both are displayed in the source section (highlighted in red), and available as separate input fields in the editor (highlighted in orange).
 
-The following image is an example of a string with plurals: while English only has 2 forms, plural and singular, other locales can have a different number of plural forms. In this case, Russian has 3 forms (highlighted in orange).
+The following image is an example of a string with plurals: while English only has two forms, plural and singular, other locales can have a different number of plural forms. In this case, Russian has three forms (highlighted in orange).
 
 ![Translation editing space for Fluent string with plurals](../../assets/images/pontoon/ui/editing_space_ftl_plurals.png "Screenshot of the translation editing space for Fluent string with plurals")
 

--- a/src/tools/pontoon/users.md
+++ b/src/tools/pontoon/users.md
@@ -80,7 +80,7 @@ There are five user roles in Pontoon:
 
 ## Managing permissions
 
-A **Team Manager** can upgrade other users’ permissions within a locale. To manage users, open the team page and select the `PERMISSIONS` tab (it will only be visible to **Team Managers** and **Administrators**).
+A Team Manager can upgrade other users’ permissions within a locale. To manage users, open the team page and select the `PERMISSIONS` tab (it will only be visible to Team Managers and Administrators).
 
 By default there’s only a `General` section: permissions defined here will apply to all projects, but can be overridden by custom project permissions.
 
@@ -97,5 +97,5 @@ By clicking `ADD CUSTOM PERMISSIONS PER PROJECT` (highlighted in orange), it’s
 ![Project permissions](../../assets/images/pontoon/users/permissions_project.png)
 
 Note that:
-* The list of translators defined for a specific project overrides the list defined in the *General* section. If a user needs to be able to translate all projects, they need to be listed in all custom permissions on top of the *General* section.
+* The list of translators defined for a specific project overrides the list defined in the `General` section. If a user needs to be able to translate all projects, they need to be listed in all custom permissions on top of the `General` section.
 * It’s not possible to override Team Managers, as they will always be able to submit translations in any of the projects available for their locale.

--- a/src/tools/pontoon/workflow.md
+++ b/src/tools/pontoon/workflow.md
@@ -42,6 +42,6 @@ General notes:
     * If in agreement, confirm the reviewer’s version by clicking the green `SAVE` button or the checkmark icon near the string in the list below the editor (it turns green when hovered).
     * If suggesting an alternative, type it into the editor, then hit the blue `SUGGEST` button. Then resubmit it to the reviewer from Phase 2.
     * Reject suggestions not considered suitable by clicking on the cross icon near the string (it turns red when hovered).
-    * If Translator A does not have the *Translator* or *Team manager* role, they will be unable to confirm or reject a suggestion. In that case, use [translation comments](glossary.md#comment) to discuss the translation with the reviewer.
+    * If Translator A does not have the Translator or Team manager role, they will be unable to confirm or reject a suggestion. In that case, use [translation comments](glossary.md#comment) to discuss the translation with the reviewer.
 
 Repeat, switching translators, until a consensus is reached.


### PR DESCRIPTION
Made style consistent across files:
Any on screen text surrounded by: ``
Italics for terms: **

Removed a lot of italics when they were used to reference a concept introduced in the documentation. Best not to overuse italics and limit only to terms (e.g. *Translation mode*).