### PR TITLE
Fix some broken links in documentation

### DIFF
--- a/src/tools/pontoon/translate.md
+++ b/src/tools/pontoon/translate.md
@@ -129,7 +129,7 @@ This workflow utilizes the full power of Pontoon’s online translation features
 
 General notes:
 * Rely on Pontoon’s [translation tools](translation_workspace.md#translation-tools-and-comments) to ensure consistency and make the translation process faster.
-* When using Firefox, make sure to have a [dictionary](https://addons.mozilla.org/firefox/dictionaries/) installed for the translation language, and that spell checking is enabled in the translation text area.
+* When using Firefox, make sure to have a [dictionary](https://addons.mozilla.org/firefox/language-tools/) installed for the translation language, and that spell checking is enabled in the translation text area.
 
 ### Phase 2: review suggestions
 

--- a/src/tools/pontoon/translation_workspace.md
+++ b/src/tools/pontoon/translation_workspace.md
@@ -263,7 +263,6 @@ The screenshot above shows a pinned comment, and the command to unpin it.
 
 Machinery shows possible translations from a variety of sources. These sources include:
 * [Pontoon’s internal translation memory](translate.md#downloading-and-uploading-translations).
-* [Microsoft Terminology](https://www.microsoft.com/Language/).
 * [Google Translate](https://translate.google.com).
 * [SYSTRAN](https://www.systran.net/).
 * [Caighdean](https://github.com/kscanne/caighdean).

--- a/src/webprojects/amo.md
+++ b/src/webprojects/amo.md
@@ -8,7 +8,7 @@ AMO refers to https://addons.mozilla.org/. It is one of Mozilla’s biggest web 
 * [AMO frontend](https://pontoon.mozilla.org/projects/amo-frontend/) covers the top page of `about:addons` and the user-facing pages of addons.mozilla.org on Firefox for Android.
 * [Discovery Pane](https://pontoon.mozilla.org/projects/amo-frontend/) is home of curated add-ons available on `about:addons`.
 
-Product updates are deployed every Thursday to production. Localizable strings can be extracted on Tuesdays, strings localized by 5pm UTC each Tuesday go live on Thursday. To report a problem, you can use [GitHub issues](https://github.com/mozilla/addons-server/issues/new).
+Product updates are deployed every Thursday to production. Localizable strings can be extracted on Tuesdays, strings localized by 5pm UTC each Tuesday go live on Thursday. To report a problem, you can use [GitHub issues](https://github.com/mozilla/addons/issues).
 
 Now let’s take a look of these components in greater details.
 


### PR DESCRIPTION
First pass of quick fixes for broken links pointed out in #265 